### PR TITLE
add handleOnClick function to close overlay

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,14 @@
 const overlay = document.getElementById("overlay");
 const login = document.getElementById("login");
+const overlayCloseBtn = document.querySelector(".group p:last-of-type");
 
-login.addEventListener("click", () => {
-  overlay.style.display = "grid";
-});
+function handleOnClick(event) {
+  if (event.target === login) {
+    overlay.style.display = "grid";
+  } else if (event.target === overlayCloseBtn) {
+    overlay.style.display = "none";
+  }
+}
+
+login.addEventListener("click", handleOnClick);
+overlay.addEventListener("click", handleOnClick);


### PR DESCRIPTION
## Issue
This PR fixes #1. 
Currently, there is no way to close the modal/overlay.

## Fix description
</br>I added ```function handleOnClick(event)```. 
</br>```login``` and ```overlay``` elements are given the ```.addEventListener("click", handleOnClick)``` method. 
</br>In this method call, the ```"click" event object``` is passed to ```function handleOnClick(event)```. 
</br>In this function, the ```event.target``` is checked in a conditional ```if statement```. 
</br>The modal/overlay display is set to "grid" or "none" dependent on what exactly was clicked. 

## Design 
This design will allow us to also handle when the ```Login``` and ```New here? Sign up!``` buttons are clicked as well, by simply adding conditional statements. This also prevents us from having to create a whole new function or pass an anonymous function. We can also add a ```function handleOnSubmit``` or ```handleOnChange``` to handle features like form validation.